### PR TITLE
basic referral changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ We, as well as others, had success using Truffle on Node.js `v12.18.2` with the 
 
 To install the latest version of Truffle: `npm install -g truffle`
 
-*Though the latest version of Truffle should work, to compile, deploy, and test our contracts, we used Truffle `v5.1.45` (which should use `solc` version `0.6.12+commit.27d51765.Emscripten.clang` and Web3.js `v1.2.1`).*
+_Though the latest version of Truffle should work, to compile, deploy, and test our contracts, we used Truffle `v5.1.45` (which should use `solc` version `0.6.12+commit.27d51765.Emscripten.clang` and Web3.js `v1.2.1`)._
 
 To install all our dependencies: `npm install`
 
@@ -24,7 +24,7 @@ To install all our dependencies: `npm install`
 
 In `.env`, set `DEVELOPMENT_ADDRESS=0x45D54B22582c79c8Fb8f4c4F2663ef54944f397a` to test deployment and also set `DEVELOPMENT_ADDRESS_SECONDARY=0x1Eeb75CFad36EDb6C996f7809f30952B0CA0B5B9` to run automated tests.
 
-To test the contracts, first fork the Ethereum mainnet. Begin by configuring `DEVELOPMENT_WEB3_PROVIDER_URL_TO_BE_FORKED` in `.env` (set to any mainnet Web3 HTTP provider JSON-RPC URL; we use a local `geth` instance, specifically a light client started with `geth --syncmode light --rpc --rpcapi eth,web3,debug,net`; Infura works too, but beware of latency and rate limiting). To start the fork, run `npm run ganache`. *If you would like to change the port, make sure to configure `scripts/ganache.js`, `scripts/test.sh`, and the `development` network in `truffle-config.js`.* Note that you will likely have to regularly restart your fork, especially when forking from a node without archive data or when using live 0x API responses to make currency exchanges.
+To test the contracts, first fork the Ethereum mainnet. Begin by configuring `DEVELOPMENT_WEB3_PROVIDER_URL_TO_BE_FORKED` in `.env` (set to any mainnet Web3 HTTP provider JSON-RPC URL; we use a local `geth` instance, specifically a light client started with `geth --syncmode light --rpc --rpcapi eth,web3,debug,net`; Infura works too, but beware of latency and rate limiting). To start the fork, run `npm run ganache`. _If you would like to change the port, make sure to configure `scripts/ganache.js`, `scripts/test.sh`, and the `development` network in `truffle-config.js`._ Note that you will likely have to regularly restart your fork, especially when forking from a node without archive data or when using live 0x API responses to make currency exchanges.
 
 To deploy the contracts to your private mainnet fork: `truffle migrate --network development --skip-dry-run --reset`
 

--- a/contracts/FuseFeeDistributor.sol
+++ b/contracts/FuseFeeDistributor.sol
@@ -65,5 +65,5 @@ contract FuseFeeDistributor is Initializable, OwnableUpgradeable {
     /**
      * @dev Receives ETH fees.
      */
-    receive() external payable { }
+    receive() external payable {}
 }

--- a/contracts/FusePoolDirectory.sol
+++ b/contracts/FusePoolDirectory.sol
@@ -325,6 +325,7 @@ contract FusePoolDirectory {
      */
     struct FusePoolUser {
         address account;
+        address referrer;
         uint256 totalBorrow;
         uint256 totalCollateral;
         uint256 health;
@@ -372,7 +373,11 @@ contract FusePoolDirectory {
 
             uint256 health = totalBorrow > 0 ? totalCollateral.mul(1e18).div(totalBorrow) : 1e36;
             if (health > maxHealth) continue;
-            detailedUsers[index] = FusePoolUser(users[i], totalBorrow, totalCollateral, health, assets);
+
+            // * Hide referrer from public function
+            address referrer = address(0);
+
+            detailedUsers[index] = FusePoolUser(users[i], referrer, totalBorrow, totalCollateral, health, assets);
             index++;
         }
 


### PR DESCRIPTION
- [x] Add referral code logic to fuse fee distributor
- [ ] Add referral code logic to compound base contracts (CToken, CEther, CErc20)

Once this is implemented and deployed, should be able to use referral logic in rari-dApp
We Will need to update sdk and front-end to use updated deposit logic I think? 